### PR TITLE
Add support for setseed

### DIFF
--- a/beholder.py
+++ b/beholder.py
@@ -2161,8 +2161,16 @@ class DeathBotProtocol(irc.IRCClient):
                     event["lltype"] &= ~t
                     if not event["lltype"]: return
         if "message" in event:
-            yield ("[{displaystring}] {player} ({role} {race} {gender} {align}) "
-                   "{message}, on T:{turns}").format(**event)
+            if "realtime" in event:
+                event["seconds"] = event["realtime"] % 60
+                minutes_tmp = (event["realtime"] - event["seconds"]) / 60
+                event["minutes"] = minutes_tmp % 60
+                event["hours"] = (minutes_tmp - event["minutes"]) / 60
+                yield ("[{displaystring}] {player} ({role} {race} {gender} {align}) "
+                       "{message}, on T:{turns}, {hours}:{minutes}:{seconds}").format(**event)
+            else:
+                yield ("[{displaystring}] {player} ({role} {race} {gender} {align}) "
+                       "{message}, on T:{turns}").format(**event)
         elif "wish" in event:
             yield ("[{displaystring}] {player} ({role} {race} {gender} {align}) "
                    'wished for "{wish}", on T:{turns}').format(**event)

--- a/beholder.py
+++ b/beholder.py
@@ -94,7 +94,7 @@ def fixdump(s):
 
 xlogfile_parse = dict.fromkeys(
     ("points", "deathdnum", "deathlev", "maxlvl", "hp", "maxhp", "deaths",
-     "starttime", "curtime", "endtime",
+     "starttime", "curtime", "endtime", "user_seed",
      "uid", "turns", "xplevel", "exp","depth","dnum","score","amulet", "lltype"), int)
 xlogfile_parse.update(dict.fromkeys(
     ("conduct", "event", "carried", "flags", "achieve"), ast.literal_eval))
@@ -2161,13 +2161,17 @@ class DeathBotProtocol(irc.IRCClient):
                     event["lltype"] &= ~t
                     if not event["lltype"]: return
         if "message" in event:
-            if "realtime" in event:
-                event["seconds"] = event["realtime"] % 60
-                minutes_tmp = (event["realtime"] - event["seconds"]) / 60
-                event["minutes"] = minutes_tmp % 60
-                event["hours"] = (minutes_tmp - event["minutes"]) / 60
+            if event["message"] == "entered the Dungeons of Doom":
+                if "user_seed" in event and "seed" in event and event["user_seed"]:
+                    yield("[{displaystring}] {player} ({role} {race} {gender} {align}) "
+                    "{message} [seed: {seed}]".format(**event))
+                else:
+                    yield("[{displaystring}] {player} ({role} {race} {gender} {align}) "
+                    "{message}".format(**event))
+            elif "realtime" in event:
+                event["realtime_fmt"] = str(event["realtime"])
                 yield ("[{displaystring}] {player} ({role} {race} {gender} {align}) "
-                       "{message}, on T:{turns}, {hours}:{minutes}:{seconds}").format(**event)
+                       "{message}, on T:{turns}, {realtime_fmt}").format(**event)
             else:
                 yield ("[{displaystring}] {player} ({role} {race} {gender} {align}) "
                        "{message}, on T:{turns}").format(**event)

--- a/beholder.py
+++ b/beholder.py
@@ -98,9 +98,9 @@ xlogfile_parse = dict.fromkeys(
      "uid", "turns", "xplevel", "exp","depth","dnum","score","amulet", "lltype"), int)
 xlogfile_parse.update(dict.fromkeys(
     ("conduct", "event", "carried", "flags", "achieve"), ast.literal_eval))
-xlogfile_parse["starttime"] = fromtimestamp_int
+#xlogfile_parse["starttime"] = fromtimestamp_int
 #xlogfile_parse["curtime"] = fromtimestamp_int
-xlogfile_parse["endtime"] = fromtimestamp_int
+#xlogfile_parse["endtime"] = fromtimestamp_int
 xlogfile_parse["realtime"] = timedelta_int
 #xlogfile_parse["deathdate"] = xlogfile_parse["birthdate"] = isodate
 #xlogfile_parse["dumplog"] = fixdump
@@ -2075,15 +2075,15 @@ class DeathBotProtocol(irc.IRCClient):
 
             # format duration string based on realtime and/or wallclock duration
             if game["starttime"] and game["endtime"]:
-                game["wallclock"] = game["endtime"] - game["startime"]
-            if game["wallclock"] != game["realtime"]:
-                game["duration_str"] = "rt"
-            if game["realtime"]:
-                game["duration_str"] += "[" + str(game["realtime"]) + "]"
-                if game["wallclock"] > game["realtime"]:
-                    game["duration_str"] += ", "
-            if game["wallclock"] and game["wallclock"] > game["realtime"]:
-                game["duration_str"] += "wc[" + str(game["wallclock"]) + "]"
+                game["wallclock"] = timedelta_int(game["endtime"] - game["startime"])
+            if game["realtime"] and game["wallclock"] == game["realtime"]:
+                game["duration_str"] = "[" + str(game["realtime"]) + "]"
+            elif game["realtime"] and not game["wallclock"]:
+                game["duration_str"] = "rt[" + str(game["realtime"]) + "]"
+            elif game["realtime"] and game["wallclock"]:
+                game["duration_str"] = "rt[" + str(game["realtime"]) + "]" + ", wc[" + str(game["wallclock"]) + "]"
+            elif game["wallclock"] and not game["realtime"]:
+                game["duration_str"] = "wc[" + str(game["wallclock"]) + "]"
 
             # !asc stats
             if not lname in self.asc[var]: self.asc[var][lname] = {}


### PR DESCRIPTION
Livelog an event when a game is started, and display the seed (if set by user).
Display realtime for progress/achievement events.

sample output from testing:
```
15:27 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law) entered the Dungeons of Doom [chosen seed: UndyneAppreciationClub]
15:30 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law) reached Mine Town, on T:1021, rt[0:03:08]
15:44 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law), 1710 points, T:1635, rt[0:06:19], wc[0:17:51], killed by an uninjured fox
16:21 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law) entered the Dungeons of Doom [chosen seed: UndyneAppreciationClub]
16:38 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law) entered the Dungeons of Doom [chosen seed: UndyneAppreciationClub]
16:38 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law) entered the Dungeons of Doom [chosen seed: ILoveUAlphys]
16:41 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law) reached Mine Town, on T:983, rt[0:02:49]
16:56 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law), 1119 points, T:1397, [0:17:37], quit
16:57 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law) entered the Dungeons of Doom [chosen seed: UndyneAppreciationClub]
16:57 <ykkie> [temi-hoem] [seed] aoei (Val Dwa Fem Law) entered the Dungeons of Doom [random seed]

```