### PR TITLE
Add !rumor command for retrieving game rumors

### DIFF
--- a/botuse.txt
+++ b/botuse.txt
@@ -32,6 +32,7 @@ Random Number Generator (RNG) commands:
                 - Pick random phrase from | separated list.
 !rng m-n        - pick random number between m and n
 !rng            - Provide information on nethack RNG workings.
+!rumor [variant] [true|false] [matchstring] - Provide a random rumor.
 
 Other:
 !tea,!coffee,etc [rcpt] - Prepare a special unique beverage for you, or rcpt.


### PR DESCRIPTION
Features many things including:
- Get rumors from most variants' lists. Even 1.3d!
- Specify true or false.
- Return a rumor matching one or more arbitrary words.
- British compatible alias.
- Caching: a given rumor file will not be downloaded more than once per
  hour, in anticipation of people likely to use !rumor multiple times in
  succession.